### PR TITLE
Set paid order status to processing rather than completed

### DIFF
--- a/woocommerce-wayforpay/woocommerce-gateway-wayforpay.php
+++ b/woocommerce-wayforpay/woocommerce-gateway-wayforpay.php
@@ -453,7 +453,7 @@ function woocommerce_wayforpay_init()
 
             if ($response['transactionStatus'] == self::ORDER_APPROVED) {
 
-                $order->update_status('completed');
+                $order->update_status('processing');
                 $order->payment_complete();
                 $order->add_order_note('WayForPay.com payment successful.<br/>WayForPay.com ID: ' . ' (' . $_REQUEST['payment_id'] . ')');
                 return true;


### PR DESCRIPTION
Не корректно ставить статус completed сразу после оплаты. В случае физического товара его ещё нужно доставить покупателю.
Для этого и есть стандартный статус processing
