### PR TITLE
Return customer to WC order details page by default

### DIFF
--- a/woocommerce-wayforpay/woocommerce-gateway-wayforpay.php
+++ b/woocommerce-wayforpay/woocommerce-gateway-wayforpay.php
@@ -369,8 +369,8 @@ function woocommerce_wayforpay_init()
                 'orderDate' => strtotime($orderDate),
                 'currency' => $currency,
                 'amount' => $order->get_total(),
-                'returnUrl' => $this->getCallbackUrl(),
-                'serviceUrl' => $this->getCallbackUrl(true),
+                'returnUrl' => $this->getCallbackUrl($order),
+                'serviceUrl' => $this->getCallbackUrl($order, true),
                 'language' => $this->getLanguage()
             );
 
@@ -422,13 +422,19 @@ function woocommerce_wayforpay_init()
         }
 
         /**
+         * @param WC_Order $order
          * @param bool $service
          * @return bool|string
          */
-        private function getCallbackUrl($service = false)
+        private function getCallbackUrl($order, $service = false)
         {
 
-            $redirect_url = ($this->redirect_page_id == "" || $this->redirect_page_id == 0) ? get_site_url() . "/" : get_permalink($this->redirect_page_id);
+            if ($this->redirect_page_id == "" || $this->redirect_page_id == 0) {
+                $redirect_url = $this->get_return_url($order);
+            else {
+                $redirect_url = get_permalink($this->redirect_page_id);
+            }
+
             if (!$service) {
                 return $redirect_url;
             }


### PR DESCRIPTION
Instead of returning customers to a homepage if admin didn't set up `returnUrl` we redirect customers to an order details page.

There they can review their order details.

Also, this change makes wayforpay plugin a "better citizen" who fits better into a WooCommerce plugins ecosystem.