### PR TITLE
Removes manual order status update for complete payments

### DIFF
--- a/woocommerce-wayforpay/woocommerce-gateway-wayforpay.php
+++ b/woocommerce-wayforpay/woocommerce-gateway-wayforpay.php
@@ -464,8 +464,6 @@ function woocommerce_wayforpay_init()
             }
 
             if ($response['transactionStatus'] == self::ORDER_APPROVED) {
-
-                $order->update_status('processing');
                 $order->payment_complete();
                 $order->add_order_note('WayForPay.com payment successful.<br/>WayForPay.com ID: ' . ' (' . $_REQUEST['payment_id'] . ')');
                 return true;


### PR DESCRIPTION
This change lets WooCommerce reduce stock levels and update order status properly.

I've checked this on my installation:
- WP: 4.9.1
- WC: 3.2.6

See following pages for the reference:
- https://docs.woocommerce.com/wc-apidocs/class-WC_Order.html#_payment_complete
- http://woocommerce.wp-a2z.org/oik_api/wc_orderpayment_complete/