### PR TITLE
fix ukrainian language on payment page

### DIFF
--- a/woocommerce-gateway-wayforpay.php
+++ b/woocommerce-gateway-wayforpay.php
@@ -463,9 +463,13 @@ function woocommerce_wayforpay_init()
 
         private function getLanguage()
         {
-            return substr(get_bloginfo('language'), 0, 2);
-        }
-
+            $lang_uk = substr(get_bloginfo('language'), 0, 2);
+		
+	    if ($lang_uk === 'uk') {
+		    $lang_uk = 'ua';
+	    }
+	    return $lang_uk;
+    }
 
         protected function isPaymentValid($response)
         {


### PR DESCRIPTION
Wordpress use country code  ISO 639-1, ukrainian language have code uk, but API use value ua for parametr 'language'. This fix on function getLanguage() replace uk on ua if the blog has language ukraininan.